### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     "require": {
         "php": "^7.0",
         "spatie/blink": "^1.0",
-        "illuminate/support": "^5.4|~5.5.x-dev"
+        "illuminate/support": "^5.4|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",
-        "orchestra/testbench": "^3.4.6|~3.5.x-dev"
+        "orchestra/testbench": "^3.4.6|~3.5.x-dev|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {
@@ -54,3 +54,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     "require": {
         "php": "^7.0",
         "spatie/blink": "^1.0",
-        "illuminate/support": "^5.4"
+        "illuminate/support": "^5.4|~5.5.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0.9",
-        "orchestra/testbench": "^3.4.6"
+        "phpunit/phpunit": "^6.2",
+        "orchestra/testbench": "^3.4.6|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-blink/phpunit.xml.dist

......                                                              6 / 6 (100%)

Time: 840 ms, Memory: 10.00MB

OK (6 tests, 6 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments