### PR TITLE
Add docblock to blink() helper function

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return \Spatie\Blink\Blink|mixed
+ */
 function blink()
 {
     $arguments = func_get_args();


### PR DESCRIPTION
Specifies return types to allow for IDE autocompletion.