### PR TITLE
Add PHP 8.1 Support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: spatie
 custom: https://spatie.be/open-source/support-us

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -15,7 +15,7 @@ jobs:
             -   name: Run PHP CS Fixer
                 uses: docker://oskarstark/php-cs-fixer-ga
                 with:
-                    args: --config=.php_cs.dist --allow-risky=yes
+                    args: --config=.php-cs-fixer.dist.php --allow-risky=yes
 
             -   name: Commit changes
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,15 +10,11 @@ jobs:
             matrix:
                 os: [ubuntu-latest, windows-latest]
                 php: [8.1, 8.0, 7.4]
-                laravel: [8.*, 7.*, 6.*]
+                laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 8.*
-                        testbench: 6.*
-                    -   laravel: 7.*
-                        testbench: 5.*
-                    -   laravel: 6.*
-                        testbench: 4.*
+                        testbench: ^6.23
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [8.0, 7.4]
+                php: [8.1, 8.0, 7.4]
                 laravel: [8.*, 7.*, 6.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,28 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ build
 composer.lock
 docs
 vendor
-.php_cs.cache
+*.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,14 +13,14 @@ $finder = Symfony\Component\Finder\Finder::create()
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config)
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'no_unused_imports' => true,
         'not_operator_with_successor_space' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => true,
         'phpdoc_scalar' => true,
         'unary_operator_spaces' => true,
         'binary_operator_spaces' => true,

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4|^8.0",
-        "spatie/blink": "^1.1.2",
-        "illuminate/support": "^6.0|^7.0|^8.0"
+        "spatie/blink": "^1.1.3",
+        "illuminate/support": "^6.0|^7.0|^8.73"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5|^9.3",
-        "orchestra/testbench": "^4.0|^5.0|^6.0"
+        "phpunit/phpunit": "^8.5|^9.5",
+        "orchestra/testbench": "^4.0|^5.0|^6.23"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     "require": {
         "php": "^7.4|^8.0",
         "spatie/blink": "^1.1.3",
-        "illuminate/support": "^6.0|^7.0|^8.73"
+        "illuminate/support": "^8.73"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.5",
-        "orchestra/testbench": "^4.0|^5.0|^6.23"
+        "orchestra/testbench": "^6.23"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds PHP 8.1 support to the tests workflow.

Additionally, it:
- drops support for Laravel < 8.x
- updates the `php-cs-fixer` workflow & config
- adds the update changelog workflow

_This repository needs its primary branch renamed from `master` to `main`._